### PR TITLE
porting changes to dunes protocol with backwards compatibility

### DIFF
--- a/src/blocktime.rs
+++ b/src/blocktime.rs
@@ -8,12 +8,18 @@ pub(crate) enum Blocktime {
 
 impl Blocktime {
   pub(crate) fn confirmed(seconds: u32) -> Self {
-    Self::Confirmed(timestamp(seconds))
+    Self::Confirmed(timestamp(seconds.into()))
   }
 
   pub(crate) fn timestamp(self) -> DateTime<Utc> {
     match self {
       Self::Confirmed(timestamp) | Self::Expected(timestamp) => timestamp,
+    }
+  }
+
+  pub(crate) fn unix_timestamp(self) -> i64 {
+    match self {
+      Self::Confirmed(timestamp) | Self::Expected(timestamp) => timestamp.timestamp(),
     }
   }
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -50,7 +50,7 @@ impl Chain {
 
   pub(crate) fn first_dune_height(self) -> u32 {
     match self {
-      Self::Mainnet => 5008400,
+      Self::Mainnet => 5084000,
       Self::Regtest => 0,
       Self::Signet => 0,
       Self::Testnet => 4250000,

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2,8 +2,8 @@ use super::*;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub(crate) struct Decimal {
-  value: u128,
-  scale: u8,
+  pub value: u128,
+  pub scale: u8,
 }
 
 impl Decimal {
@@ -21,6 +21,30 @@ impl Decimal {
       ),
       None => bail!("excessive precision"),
     }
+  }
+}
+
+impl Display for Decimal {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    let magnitude = 10u128.checked_pow(self.scale.into()).ok_or(fmt::Error)?;
+
+    let integer = self.value / magnitude;
+    let mut fraction = self.value % magnitude;
+
+    write!(f, "{integer}")?;
+
+    if fraction > 0 {
+      let mut width: usize = self.scale.into();
+
+      while fraction % 10 == 0 {
+        fraction /= 10;
+        width -= 1;
+      }
+
+      write!(f, ".{fraction:0>width$}", width = width)?;
+    }
+
+    Ok(())
   }
 }
 

--- a/src/dunes.rs
+++ b/src/dunes.rs
@@ -3,19 +3,19 @@ use {
   super::*,
 };
 
-pub use {edict::Edict, dune::Dune, dune_id::DuneId, dunestone::Dunestone};
+pub use {edict::Edict, dune::Dune, dune_id::DuneId, dunestone::Dunestone, terms::Terms};
 
-pub(crate) use {etching::Etching, mint::Mint, pile::Pile, spaced_dune::SpacedDune};
+pub(crate) use {etching::Etching, pile::Pile, spaced_dune::SpacedDune};
 
 pub(crate) const CLAIM_BIT: u128 = 1 << 48;
 pub const MAX_DIVISIBILITY: u8 = 38;
-pub(crate) const MAX_LIMIT: u128 = 1 << 64;
+pub(crate) const MAX_LIMIT: u128 = u64::MAX as u128;
 const RESERVED: u128 = 6402364363415443603228541259936211926;
 
 mod edict;
 mod etching;
 mod flag;
-mod mint;
+mod terms;
 mod pile;
 mod dune;
 mod dune_id;
@@ -25,6 +25,25 @@ mod tag;
 pub mod varint;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, PartialEq)]
+pub enum MintError {
+  Cap(u128),
+  End(u64),
+  Start(u64),
+  Unmintable,
+}
+
+impl Display for MintError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    match self {
+      MintError::Cap(cap) => write!(f, "limited to {cap} mints"),
+      MintError::End(end) => write!(f, "mint ended on block {end}"),
+      MintError::Start(start) => write!(f, "mint starts on block {start}"),
+      MintError::Unmintable => write!(f, "not mintable"),
+    }
+  }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/dunes/dune_id.rs
+++ b/src/dunes/dune_id.rs
@@ -2,8 +2,8 @@ use {super::*, std::num::TryFromIntError};
 
 #[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, Ord, PartialOrd)]
 pub struct DuneId {
-  pub height: u32,
-  pub index: u16,
+  pub height: u64,
+  pub index: u32,
 }
 
 impl TryFrom<u128> for DuneId {
@@ -11,8 +11,8 @@ impl TryFrom<u128> for DuneId {
 
   fn try_from(n: u128) -> Result<Self, Self::Error> {
     Ok(Self {
-      height: u32::try_from(n >> 16)?,
-      index: u16::try_from(n & 0xFFFF).unwrap(),
+      height: u64::try_from(n >> 16)?,
+      index: u32::try_from(n & 0xFFFF).unwrap(),
     })
   }
 }
@@ -25,7 +25,7 @@ impl From<DuneId> for u128 {
 
 impl Display for DuneId {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(f, "{}/{}", self.height, self.index,)
+    write!(f, "{}:{}", self.height, self.index,)
   }
 }
 
@@ -34,7 +34,7 @@ impl FromStr for DuneId {
 
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let (height, index) = s
-        .split_once('/')
+        .split_once(':')
         .ok_or_else(|| anyhow!("invalid dune ID: {s}"))?;
 
     Ok(Self {
@@ -86,19 +86,19 @@ mod tests {
         index: 2
       }
       .to_string(),
-      "1/2"
+      "1:2"
     );
   }
 
   #[test]
   fn from_str() {
-    assert!("/".parse::<DuneId>().is_err());
-    assert!("1/".parse::<DuneId>().is_err());
-    assert!("/2".parse::<DuneId>().is_err());
-    assert!("a/2".parse::<DuneId>().is_err());
-    assert!("1/a".parse::<DuneId>().is_err());
+    assert!(":".parse::<DuneId>().is_err());
+    assert!("1:".parse::<DuneId>().is_err());
+    assert!(":2".parse::<DuneId>().is_err());
+    assert!("a:2".parse::<DuneId>().is_err());
+    assert!("1:a".parse::<DuneId>().is_err());
     assert_eq!(
-      "1/2".parse::<DuneId>().unwrap(),
+      "1:2".parse::<DuneId>().unwrap(),
       DuneId {
         height: 1,
         index: 2
@@ -125,7 +125,7 @@ mod tests {
       height: 1,
       index: 2,
     };
-    let json = "\"1/2\"";
+    let json = "\"1:2\"";
     assert_eq!(serde_json::to_string(&dune_id).unwrap(), json);
     assert_eq!(serde_json::from_str::<DuneId>(json).unwrap(), dune_id);
   }

--- a/src/dunes/edict.rs
+++ b/src/dunes/edict.rs
@@ -6,3 +6,24 @@ pub struct Edict {
   pub amount: u128,
   pub output: u128,
 }
+
+impl Edict {
+  pub(crate) fn from_integers(
+    tx: &Transaction,
+    id: u128,
+    amount: u128,
+    output: u128,
+  ) -> Option<Self> {
+    let dune_id = DuneId::try_from(id).ok()?;
+
+    if dune_id.height == 0 && dune_id.index > 0 {
+      return None;
+    }
+
+    if output > u128::try_from(tx.output.len()).ok()? {
+      return None;
+    }
+
+    Some(Self { id, amount, output })
+  }
+}

--- a/src/dunes/etching.rs
+++ b/src/dunes/etching.rs
@@ -2,9 +2,11 @@ use super::*;
 
 #[derive(Default, Serialize, Debug, PartialEq, Copy, Clone)]
 pub struct Etching {
-  pub divisibility: u8,
-  pub mint: Option<Mint>,
+  pub divisibility: Option<u8>,
+  pub terms: Option<Terms>,
+  pub premine: Option<u128>,
   pub dune: Option<Dune>,
-  pub spacers: u32,
+  pub spacers: Option<u32>,
   pub symbol: Option<char>,
+  pub turbo: bool,
 }

--- a/src/dunes/flag.rs
+++ b/src/dunes/flag.rs
@@ -1,8 +1,9 @@
 pub(super) enum Flag {
-  Etch = 0,
-  Mint = 1,
+  Etching = 0,
+  Terms = 1,
+  Turbo = 2,
   #[allow(unused)]
-  Burn = 127,
+  Cenotaph = 127,
 }
 
 impl Flag {
@@ -29,7 +30,7 @@ mod tests {
   #[test]
   fn mask() {
     assert_eq!(Flag::Etch.mask(), 0b1);
-    assert_eq!(Flag::Burn.mask(), 1 << 127);
+    assert_eq!(Flag::Cenotaph.mask(), 1 << 127);
   }
 
   #[test]

--- a/src/dunes/pile.rs
+++ b/src/dunes/pile.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub(crate) struct Pile {
   pub(crate) amount: u128,
   pub(crate) divisibility: u8,
@@ -25,9 +26,7 @@ impl Display for Pile {
       write!(f, "{whole}.{fractional:0>width$}")?;
     }
 
-    if let Some(symbol) = self.symbol {
-      write!(f, "\u{00A0}{symbol}")?;
-    }
+    write!(f, "\u{A0}{}", self.symbol.unwrap_or('¤'))?;
 
     Ok(())
   }

--- a/src/dunes/spaced_dune.rs
+++ b/src/dunes/spaced_dune.rs
@@ -6,6 +6,12 @@ pub struct SpacedDune {
   pub(crate) spacers: u32,
 }
 
+impl SpacedDune {
+  pub fn new(dune: Dune, spacers: u32) -> Self {
+    Self { dune, spacers }
+  }
+}
+
 impl FromStr for SpacedDune {
   type Err = Error;
 

--- a/src/dunes/tag.rs
+++ b/src/dunes/tag.rs
@@ -6,11 +6,17 @@ pub(super) enum Tag {
   Flags = 2,
   Dune = 4,
   Limit = 6,
-  Term = 8,
-  Deadline = 10,
-  DefaultOutput = 12,
+  OffsetEnd = 8,
+  Deadline = 10, // will be ignored
+  Pointer = 12,
+  HeightStart = 14,
+  OffsetStart = 16,
+  HeightEnd = 18,
+  Cap = 20,
+  Premine = 22,
+
   #[allow(unused)]
-  Burn = 254,
+  Cenotaph = 254,
 
   Divisibility = 1,
   Spacers = 3,

--- a/src/dunes/terms.rs
+++ b/src/dunes/terms.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+pub struct Terms {
+  pub limit: Option<u128>,
+  pub cap: Option<u128>,
+  pub height: (Option<u64>, Option<u64>),
+  pub offset: (Option<u64>, Option<u64>),
+}

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -327,7 +327,7 @@ impl<'index> Updater<'_> {
     log::info!(
       "Block {} at {} with {} transactions…",
       self.height,
-      timestamp(block.header.time),
+      timestamp(block.header.time.into()),
       block.txdata.len()
     );
 

--- a/src/inscription_id.rs
+++ b/src/inscription_id.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, PartialEq, Copy, Clone, Hash, Eq)]
+#[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, PartialOrd, Ord)]
 pub struct InscriptionId {
   pub(crate) txid: Txid,
   pub(crate) index: u32,

--- a/src/subcommand/balances.rs
+++ b/src/subcommand/balances.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Output {
-  pub dunes: BTreeMap<Dune, BTreeMap<OutPoint, u128>>,
+  pub dunes: BTreeMap<SpacedDune, BTreeMap<OutPoint, u128>>,
 }
 
 pub(crate) fn run(options: Options) -> SubcommandResult {

--- a/src/subcommand/dunes.rs
+++ b/src/subcommand/dunes.rs
@@ -7,20 +7,24 @@ pub struct Output {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct DuneInfo {
+  pub block: u64,
   pub burned: u128,
   pub divisibility: u8,
   pub etching: Txid,
-  pub height: u32,
+  pub height: u64,
   pub id: DuneId,
-  pub index: u16,
-  pub mint: Option<MintEntry>,
-  pub mints: u64,
+  pub index: u32,
+  pub terms: Option<Terms>,
+  pub mints: u128,
   pub number: u64,
+  pub premine: u128,
   pub dune: Dune,
   pub spacers: u32,
   pub supply: u128,
   pub symbol: Option<char>,
   pub timestamp: DateTime<Utc>,
+  pub turbo: bool,
+  pub tx: u32,
 }
 
 pub(crate) fn run(options: Options) -> SubcommandResult {
@@ -40,37 +44,44 @@ pub(crate) fn run(options: Options) -> SubcommandResult {
       .map(
         |(
           id,
-          DuneEntry {
+          entry @ DuneEntry {
+            block,
             burned,
             divisibility,
             etching,
-            mint,
+            terms,
             mints,
             number,
+            premine,
             dune,
             spacers,
             supply,
             symbol,
             timestamp,
+            turbo,
           },
         )| {
           (
             dune,
             DuneInfo {
+              block,
               burned,
               divisibility,
               etching,
               height: id.height,
               id,
               index: id.index,
-              mint,
+              terms,
               mints,
               number,
+              premine,
               timestamp: crate::timestamp(timestamp),
               dune,
               spacers,
               supply,
               symbol,
+              turbo,
+              tx: id.index,
             },
           )
         },

--- a/src/subcommand/server/query.rs
+++ b/src/subcommand/server/query.rs
@@ -1,0 +1,62 @@
+use super::*;
+
+pub(super) enum Block {
+    Height(u32),
+    Hash(BlockHash),
+}
+
+impl FromStr for Block {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(if s.len() == 64 {
+            Self::Hash(s.parse()?)
+        } else {
+            Self::Height(s.parse()?)
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum Inscription {
+    Id(InscriptionId),
+    Number(i32),
+}
+
+impl FromStr for Inscription {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(if s.contains('i') {
+            Self::Id(s.parse()?)
+        } else {
+            Self::Number(s.parse()?)
+        })
+    }
+}
+
+impl Display for Inscription {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Id(id) => write!(f, "{id}"),
+            Self::Number(number) => write!(f, "{number}"),
+        }
+    }
+}
+
+pub(super) enum Dune {
+    SpacedDune(SpacedDune),
+    DuneId(DuneId),
+}
+
+impl FromStr for Dune {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(':') {
+            Ok(Self::DuneId(s.parse()?))
+        } else {
+            Ok(Self::SpacedDune(s.parse()?))
+        }
+    }
+}

--- a/src/subcommand/wallet/etch.rs
+++ b/src/subcommand/wallet/etch.rs
@@ -44,7 +44,7 @@ impl Etch {
     );
 
     let minimum_at_height =
-        Dune::minimum_at_height(options.chain(), Height(u32::try_from(count).unwrap() + 1));
+        Dune::minimum_at_height(options.chain(), Height((u32::try_from(count).unwrap() + 1)));
 
     ensure!(
       dune >= minimum_at_height,
@@ -63,19 +63,21 @@ impl Etch {
 
     let dunestone = Dunestone {
       etching: Some(Etching {
-        divisibility: self.divisibility,
-        mint: None,
+        divisibility: Some(self.divisibility),
+        terms: None,
+        premine: None,
         dune: Some(dune),
-        spacers,
+        spacers: Some(spacers),
         symbol: Some(self.symbol),
+        turbo: false,
       }),
       edicts: vec![Edict {
         amount: self.supply.to_amount(self.divisibility)?,
         id: 0,
         output: 1,
       }],
-      default_output: None,
-      burn: false,
+      pointer: None,
+      cenotaph: false,
     };
 
     let script_pubkey = dunestone.encipher();

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -8,6 +8,7 @@ pub(crate) use {
   inscription::InscriptionHtml,
   inscriptions::InscriptionsHtml,
   output::OutputHtml,
+  output::OutputJson,
   page_config::PageConfig,
   preview::{
     PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml, PreviewUnknownHtml,
@@ -15,7 +16,10 @@ pub(crate) use {
   },
   range::RangeHtml,
   rare::RareTxt,
+  dune::DuneEntryJson,
   dune::DuneHtml,
+  dune::DuneJson,
+  dune::DuneOutputJson,
   dune_balances::DuneBalancesHtml,
   dunes::DunesHtml,
   sat::SatHtml,
@@ -128,7 +132,7 @@ mod tests {
   <body>
   <header>
     <nav>
-      <a href=/>Doginals<sup>alpha</sup></a>
+      <a href=/>Dunes<sup>alpha</sup></a>
       .*
       <a href=/rare.txt>rare.txt</a>
       <form action=/search method=get>
@@ -154,7 +158,7 @@ mod tests {
         domain: None,
         index_sats: true,
       }),),
-      r".*<nav>\s*<a href=/>Doginals<sup>alpha</sup></a>.*"
+      r".*<nav>\s*<a href=/>Dunes<sup>alpha</sup></a>.*"
     );
   }
 
@@ -166,7 +170,7 @@ mod tests {
         domain: None,
         index_sats: false,
       }),),
-      r".*<nav>\s*<a href=/>Doginals<sup>alpha</sup></a>.*\s*<form action=/search.*",
+      r".*<nav>\s*<a href=/>Dunes<sup>alpha</sup></a>.*\s*<form action=/search.*",
     );
   }
 
@@ -178,7 +182,7 @@ mod tests {
         domain: None,
         index_sats: true,
       }),),
-      r".*<nav>\s*<a href=/>Doginals<sup>signet</sup></a>.*"
+      r".*<nav>\s*<a href=/>Dunes<sup>signet</sup></a>.*"
     );
   }
 }

--- a/src/templates/dune.rs
+++ b/src/templates/dune.rs
@@ -1,10 +1,39 @@
 use super::*;
 
-#[derive(Boilerplate)]
+#[derive(Boilerplate, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct DuneHtml {
   pub(crate) entry: DuneEntry,
   pub(crate) id: DuneId,
+  pub(crate) mintable: bool,
   pub(crate) inscription: Option<InscriptionId>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DuneEntryJson {
+  pub(crate) burned: u128,
+  pub(crate) divisibility: u8,
+  pub(crate) etching: Txid,
+  pub(crate) mint: Option<Terms>,
+  pub(crate) mints: u128,
+  pub(crate) number: u64,
+  pub(crate) dune: SpacedDune,
+  pub(crate) supply: u128,
+  pub(crate) symbol: Option<char>,
+  pub(crate) timestamp: u64,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DuneJson {
+  pub(crate) entry: DuneEntryJson,
+  pub(crate) id: DuneId,
+  pub(crate) mintable: bool,
+  pub(crate) inscription: Option<InscriptionId>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DuneOutputJson {
+  pub(crate) dune: SpacedDune,
+  pub(crate) balances: Pile,
 }
 
 impl PageContent for DuneHtml {
@@ -50,7 +79,7 @@ mod tests {
 <iframe .* src=/preview/0{64}i0></iframe>
 <dl>
   <dt>id</dt>
-  <dd>10/9</dd>
+  <dd>10:9</dd>
   <dt>number</dt>
   <dd>25</dd>
   <dt>supply</dt>

--- a/src/templates/dune_balances.rs
+++ b/src/templates/dune_balances.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Boilerplate, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DuneBalancesHtml {
-  pub balances: BTreeMap<Dune, BTreeMap<OutPoint, u128>>,
+  pub balances: BTreeMap<SpacedDune, BTreeMap<OutPoint, u128>>,
 }
 
 impl PageContent for DuneBalancesHtml {

--- a/src/templates/home.rs
+++ b/src/templates/home.rs
@@ -23,7 +23,7 @@ impl HomeHtml {
 
 impl PageContent for HomeHtml {
   fn title(&self) -> String {
-    "Doginals".to_string()
+    "Dunes".to_string()
   }
 }
 

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -16,6 +16,38 @@ impl PageContent for OutputHtml {
   }
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct OutputJson {
+  pub address: Option<String>,
+  pub inscriptions: Vec<InscriptionId>,
+  pub dunes: Vec<(SpacedDune, Pile)>,
+  pub script_pubkey: String,
+  pub transaction: String,
+  pub value: u64,
+}
+
+impl OutputJson {
+  pub fn new(
+    chain: Chain,
+    inscriptions: Vec<InscriptionId>,
+    outpoint: OutPoint,
+    output: TxOut,
+    dunes: Vec<(SpacedDune, Pile)>,
+  ) -> Self {
+    Self {
+      address: chain
+          .address_from_script(&output.script_pubkey)
+          .ok()
+          .map(|address| address.to_string()),
+      inscriptions,
+      dunes,
+      script_pubkey: output.script_pubkey.asm(),
+      transaction: outpoint.txid.to_string(),
+      value: output.value,
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use {

--- a/templates/block.html
+++ b/templates/block.html
@@ -2,7 +2,7 @@
 <dl>
   <dt>hash</dt><dd class=monospace>{{self.hash}}</dd>
   <dt>target</dt><dd class=monospace>{{self.target}}</dd>
-  <dt>timestamp</dt><dd><time>{{timestamp(self.block.header.time)}}</time></dd>
+  <dt>timestamp</dt><dd><time>{{timestamp(self.block.header.time.into())}}</time></dd>
   <dt>size</dt><dd>{{self.block.size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
   %% if self.height.0 > 0 {

--- a/templates/dune.html
+++ b/templates/dune.html
@@ -1,54 +1,72 @@
 <h1>{{ self.entry.spaced_dune() }}</h1>
 <dl>
-  <dt>id</dt>
-  <dd>{{ self.id }}</dd>
   <dt>number</dt>
   <dd>{{ self.entry.number }}</dd>
   <dt>timestamp</dt>
   <dd><time>{{ timestamp(self.entry.timestamp) }}</time></dd>
-  <dt>etching block height</dt>
+  <dt>id</dt>
+  <dd>{{ self.id }}</dd>
+  <dt>etching block</dt>
   <dd><a href=/block/{{ self.id.height }}>{{ self.id.height }}</a></dd>
-  <dt>etching transaction index</dt>
+  <dt>etching transaction</dt>
   <dd>{{ self.id.index }}</dd>
   <dt>mint</dt>
-  %% if let Some(mint) = self.entry.mint {
+  %% if let Some(terms) = self.entry.terms {
   <dd>
     <dl>
-      <dt>deadline</dt>
-      %% if let Some(deadline) = mint.deadline {
-      <dd><time>{{ timestamp(deadline) }}</time></dd>
+      <dt>start</dt>
+      %% if let Some(start) = self.entry.start() {
+      <dd><a href=/block/{{ start }}>{{ start }}</a></dd>
       %% } else {
       <dd>none</dd>
       %% }
       <dt>end</dt>
-      %% if let Some(end) = mint.end {
+      %% if let Some(end) = self.entry.end() {
       <dd><a href=/block/{{ end }}>{{ end }}</a></dd>
       %% } else {
       <dd>none</dd>
       %% }
-      <dt>limit</dt>
-      %% if let Some(limit) = mint.limit {
-      <dd>{{ Pile{ amount: limit, divisibility: self.entry.divisibility, symbol: self.entry.symbol } }}</dd>
+      <dt>amount</dt>
+      %% if let Some(limit) = terms.limit {
+      <dd>{{ self.entry.pile(limit) }}</dd>
       %% } else {
       <dd>none</dd>
       %% }
       <dt>mints</dt>
       <dd>{{ self.entry.mints }}</dd>
+      <dt>cap</dt>
+      %% if let Some(cap) = terms.cap {
+      <dd>{{ terms.cap.unwrap() }}</dd>
+      <dt>remaining</dt>
+      <dd>{{ terms.cap.unwrap_or_default() - self.entry.mints }}</dd>
+      %% } else {
+      <dd>none</dd>
+      <dt>remaining</dt>
+      <dd>unlimited</dd>
+      %% }
+      <dt>mintable</dt>
+      <dd>{{ self.mintable }}</dd>
     </dl>
   </dd>
   %% } else {
   <dd>no</dd>
   %% }
   <dt>supply</dt>
-  <dd>{{ Pile{ amount: self.entry.supply, divisibility: self.entry.divisibility, symbol: self.entry.symbol } }}</dd>
+  <dd>{{ self.entry.pile(self.entry.supply()) }}</dd>
+  <dt>premine</dt>
+  <dd>{{ self.entry.pile(self.entry.premine) }}</dd>
+  <dt>premine percentage</dt>
+  <dd>{{ Decimal { value: ((self.entry.premine as f64 / self.entry.supply() as f64) * 10000.0) as u128, scale: 2 } }}%</dd>
   <dt>burned</dt>
-  <dd>{{ Pile{ amount: self.entry.burned, divisibility: self.entry.divisibility, symbol: self.entry.symbol } }}</dd>
+  <dd>{{ self.entry.pile(self.entry.burned) }}</dd>
   <dt>divisibility</dt>
   <dd>{{ self.entry.divisibility }}</dd>
   %% if let Some(symbol) = self.entry.symbol {
   <dt>symbol</dt>
   <dd>{{ symbol }}</dd>
   %% }
+  <dt>turbo</dt>
+  <dd>{{ self.entry.turbo }}</dd>
   <dt>etching</dt>
   <dd><a class=monospace href=/tx/{{ self.entry.etching }}>{{ self.entry.etching }}</a></dd>
 </dl>


### PR DESCRIPTION
Porting of latest protocol changes from BTC without breaking current etched, minted and transferred dunes.

#### Changes
- new minting terms amount (former known as limit), cap, start height, end height, start offset, end offset (former known as term).
- premine (instead of having to create an edict on etching for dunes allocation while etching)
- default symbol ¤ for dunes without a given symbol
- changed dune id representation to block:tx
- cenotaph
- renames default output to pointer

This will be merged when the server has finished indexing and the change is public.